### PR TITLE
remove ignore scripts

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -41,7 +41,7 @@ runs:
     - name: ⬇️  Install
       shell: "bash"
       run: | 
-        pnpm install --ignore-scripts --frozen-lockfile --os=linux --cpu=x64
+        pnpm install --frozen-lockfile --os=linux --cpu=x64
 
     - name: 🔄 Save node_modules and pnpm store to cache
       if: steps.node_modules-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
> With the release of pnpm v10, the team shifted to a "secure by default" stance. In previous versions, all preinstall, install, and postinstall scripts ran automatically unless you opted out with --ignore-scripts. In v10, that logic is flipped.
> 
> Why --ignore-scripts is now redundant
> In pnpm v10, the package manager automatically blocks all scripts unless they are explicitly listed in your package.json.
> 
> Using the old flag while also using the new onlyBuiltDependencies field is essentially "double-locking" the door. If you keep the flag, even the dependencies you want to build (like sharp or esbuild) will be blocked, likely breaking your application.
